### PR TITLE
Removed openjpeg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,6 @@ RUN yum install -y expat-devel
 # rasterio.
 RUN yum install -y compat-expat1.i686
 
-# ecmwf_grib.
-RUN yum install -y openjpeg-devel
-
 # nco.
 RUN yum install -y bison byacc flex gsl-devel antlr
 


### PR DESCRIPTION
We had an issue in the jasper recipe (https://github.com/ioos/conda-recipes/pull/284) that forced me to use openjpeg.  Now that the issue is fixed it is better to rely on jasper instead.
